### PR TITLE
Add TOC Generator

### DIFF
--- a/.github/workflows/toc.yaml
+++ b/.github/workflows/toc.yaml
@@ -1,0 +1,8 @@
+on: push
+name: TOC Generator
+jobs:
+  generateTOC:
+    name: TOC Generator
+    runs-on: ubuntu-latest
+    steps:
+      - uses: technote-space/toc-generator@v4

--- a/README.md
+++ b/README.md
@@ -1,3 +1,31 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**
+
+- [Practical Large Language Models: What can you do with LLMs at home?](#practical-large-language-models-what-can-you-do-with-llms-at-home)
+  - [The Emergence of KnowledgeOps](#the-emergence-of-knowledgeops)
+    - [Amir Feizpour (CEO @ Aggregate Intellect)](#amir-feizpour-ceo--aggregate-intellect)
+  - [Commercializing LLMs: Lessons and Ideas for Agile Innovation](#commercializing-llms-lessons-and-ideas-for-agile-innovation)
+    - [Josh Seltzer (CTO @ Nexxt Intelligence)](#josh-seltzer-cto--nexxt-intelligence)
+  - [Integrating LLMs into Your Product: Considerations and Best Practices](#integrating-llms-into-your-product-considerations-and-best-practices)
+    - [Denys Linkov (ML Lead @ Voiceflow)](#denys-linkov-ml-lead--voiceflow)
+  - [Incorporating Large Language Models into Enterprise Analytics: Navigating the Landscape of In-Context Learning and Agents](#incorporating-large-language-models-into-enterprise-analytics-navigating-the-landscape-of-in-context-learning-and-agents)
+    - [Rajiv Shah (MLE @ Huggingface)](#rajiv-shah-mle--huggingface)
+  - [Generative AI: Ethics, Accessibility, Legal Risk Mitigation](#generative-ai-ethics-accessibility-legal-risk-mitigation)
+    - [Noelle Russell (Global AI Solutions Lead @ Accenture)](#noelle-russell-global-ai-solutions-lead--accenture)
+  - [LLMOps: Expanding the Capabilities of Language Models with External Tools](#llmops-expanding-the-capabilities-of-language-models-with-external-tools)
+    - [Suhas Pai (CTO @ Bedrock AI)](#suhas-pai-cto--bedrock-ai)
+  - [Leveraging Language Models for Training Data Generation and Tool Learning](#leveraging-language-models-for-training-data-generation-and-tool-learning)
+    - [Gordon Gibson (ML Lead @ Ada)](#gordon-gibson-ml-lead--ada)
+  - [Optimizing Large Language Models with Reinforcement Learning-Based Prompts](#optimizing-large-language-models-with-reinforcement-learning-based-prompts)
+    - [Mingkai Deng (PhD Student @ CMU)](#mingkai-deng-phd-student--cmu)
+- [Contributions Guideline](#contributions-guideline)
+  - [Making Changes through Pull Requests](#making-changes-through-pull-requests)
+  - [Suggesting Changes through Issues](#suggesting-changes-through-issues)
+  - [Other Useful Resources](#other-useful-resources)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Practical Large Language Models: What can you do with LLMs at home?
 This repo contains material and information from the workshop run by [Aggregate Intellect](https://ai.science) to update and educate our community about the explosive progress in language models (and generally generative models). We will continue adding material to this repository, but feel free to add any questions or suggestions through pull requests or through reporting issues. 
 


### PR DESCRIPTION
# Description

This PR suggests the addition of TOC Generator to generate a table of contents for better navigation. The GitHub workflow utilizes technote-space/toc-generator`, see [here](https://github.com/technote-space/toc-generator) for further customization.

## Turn on Read and Write Permissions for Workflow

For this workflow to run, the repository has to set Workflow Permissions to "Read and write permissions".

<img width="791" alt="Screenshot 2023-04-29 at 2 05 08 PM" src="https://user-images.githubusercontent.com/63731742/235317580-ff318815-9007-4b5e-bd44-728521c10387.png">

See more on [Managing GitHub Actions settings for a repository](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository)


## Type of change

- [X] CI: Added TOC Generator GitHub workflow, set to create a table of contents on push.
- [X] Chore: Updated `README.md` to include a table of contents, generated via TOC Generator